### PR TITLE
Use .2 precision when outputting time data

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -141,7 +141,7 @@ else if (argv._[0] === 'data') {
                 var h = hours[key];
                 return {
                     date: h.date,
-                    hours: Number(sprintf('%.1f', h.hours))
+                    hours: Number(sprintf('%.2f', h.hours))
                 };
             })
         } ], null, 2));


### PR DESCRIPTION
I think that 60 minutes in an hour warrants .2 precision.
