### PR TITLE
cmd: add `ls` alias

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -191,7 +191,7 @@ else if (argv._[0] === 'csv') {
         );
     }));
 }
-else if (argv._[0] === 'list') {
+else if (argv._[0] === 'list' || argv._[0] === 'ls') {
     var s = db.createReadStream({
         gt: 'time!' + (argv.gt || ''),
         lt: 'time!' + (argv.lt || '~')


### PR DESCRIPTION
Allows the use of `clocker ls` to list entries. As this is probably the most used command in clocker, it's neat to have. Not sure if this should be done this way, or through minimist's `alias` field. Thanks!