### PR TITLE
Add verbose mode for report command

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -248,13 +248,8 @@ else if (argv._[0] === 'list' || argv._[0] === 'ls') {
 
         printEntry(row.key, start, end, elapsed, row.value.type, row.value.archive);
 
-        if (argv.verbose && row.value.message) {
-            var lines = row.value.message.split('\n');
-            console.log();
-            lines.forEach(function (line) {
-                console.log('    ' + line);
-            });
-            console.log();
+        if (argv.verbose) {
+            printMessage(row.value.message)
         }
     }));
 }
@@ -379,6 +374,9 @@ else if (argv._[0] === 'report') {
         var elapsed = (end ? end : new Date) - start;
 
         printEntry(row.key, start, end, elapsed, row.value.type, row.value.archive);
+        if(argv.verbose) {
+            printMessage(row.value.message)
+        }
 
         sumsByType[row.value.type] ? sumsByType[row.value.type] += elapsed : sumsByType[row.value.type] = elapsed;
 
@@ -576,6 +574,17 @@ function printDate(date) {
   ];
 
   return date.getDate() + ' ' + monthNames[date.getMonth()] + ' ' + date.getFullYear();
+}
+
+function printMessage(message) {
+    if(message) {
+        var lines = message.split('\n');
+        console.log();
+        lines.forEach(function (line) {
+            console.log('    ' + line);
+        });
+        console.log();
+    }
 }
 
 function addData (obj) {

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -24,8 +24,9 @@ usage:
     Show dates between lt and gt. Show archived dates with -a.
     Optionally filter by TYPE, a string or /regex/.
 
-  clocker report {--reportDay DATE}
+  clocker report {-v --reportDay DATE}
     Show all logged hours of a specific day.
+    In verbose mode (-v), also show clocked messages.
     If no --reportDay is set, the current day will be used.
 
   clocker csv {--gt DATE, --lt DATE, --props FIELDS, -a}


### PR DESCRIPTION
Sometimes it would be very useful (at least to me) to see the clocked messages in the `report` output, too. Therefore and to be consistent with the `list` interface, I have added the verbose argument to the `report` command.

Hopefully this is useful for someone else and can be merged into the next release. 🙂 