### PR TITLE
Add option "--filter"

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -69,7 +69,8 @@ program
   .command('data')
   .description('generate invoicer-compatible json output')
   .option('-d, --datadir <path>')
-  .option('-t, --type <value>', 'filter by type, a string or /regex/')
+  .option('--filter <key=value>', 'filter by key, value as string or /regex/', collect, [])
+  .option('-t, --type <value>', 'short for --filter "type=<value>"')
   .option('--gt <date>', 'show dates from gt on')
   .option('--lt <date>', 'show dates upto')
   .option('-a, --all', 'include archived dates')
@@ -81,7 +82,8 @@ program
   .description('show data entries')
   .option('-d, --datadir <path>')
   .option('-v, --verbose', 'also show clocked messages')
-  .option('-t, --type <value>', 'filter by type, a string or /regex/')
+  .option('--filter <key=value>', 'filter by key, value as string or /regex/', collect, [])
+  .option('-t, --type <value>', 'short for --filter "type=<value>"')
   .option('--gt <date>', 'show dates from gt on')
   .option('--lt <date>', 'show dates upto')
   .option('-a, --all', 'include archived dates')
@@ -100,7 +102,8 @@ program
   .command('csv')
   .description('generate CSV output')
   .option('-d, --datadir <path>')
-  .option('-t, --type <value>', 'filter by type, a string or /regex/')
+  .option('--filter <key=value>', 'filter by key, value as string or /regex/', collect, [])
+  .option('-t, --type <value>', 'short for --filter "type=<value>"')
   .option('--gt <date>', 'show dates from gt on')
   .option('--lt <date>', 'show dates upto')
   .option('-a, --all', 'include archived dates')
@@ -508,16 +511,22 @@ function initialize (cmd) {
 
 function getFilter (cmd) {
   var filter = {}
+  cmd.filter = cmd.filter || []
 
   if (cmd.type) {
-    if (cmd.type[0] === '/' && cmd.type.slice(-1)[0] === '/') {
-      // regex
-      extendFilter(filter, (e) => RegExp(cmd.type.slice(1, -1)).test(e.data.type))
+    cmd.filter.push('type=' + cmd.type)
+  }
+
+  cmd.filter.forEach((cmdFilter) => {
+    var kv = cmdFilter.split('=')
+    if (isRegex(kv[1])) {
+      extendFilter(filter, (e) => RegExp(kv[1].slice(1, -1)).test(e.data[kv[0]]))
     } else {
       // string
-      extendFilter(filter, (e) => e.data.type === cmd.type)
+      // ignore eslint rule "eqeqeq" to allow type-converting comparison
+      extendFilter(filter, (e) => e.data[kv[0]] == kv[1]) // eslint-disable-line eqeqeq
     }
-  }
+  })
 
   if (cmd.gt) {
     filter.gt = cmd.gt
@@ -661,6 +670,15 @@ function success (msg) {
   }
 }
 
+function isRegex (str) {
+  return (str[0] === '/' && str.slice(-1)[0] === '/')
+}
+
 function cmdlist (val) {
   return val.split(',')
+}
+
+function collect (val, memo) {
+  memo.push(val)
+  return memo
 }


### PR DESCRIPTION
I often use additional fields with the help of `clocker set`, e.g., `clocker set billable yes`. As of now it was only possible to filter for dates (`--gt`, `--lt`) and types (`--type`). I added the option `--filter` to filter for additional fields. The `--type` now internally uses the same mechanism.

For instance, this supports for `clocker data --filter "type=BAZCORP" --filter "billable=yes"`, or `clocker data -t BAZCORP --filter "billable=yes"` for short.